### PR TITLE
feat: make list item text configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,24 @@ git submodule add https://github.com/gearsdigital/enhanced-toolbar-link-dialog.g
 
 ## Configuration
 
-No configuration necessary 🥳
+The list item text is created using the [Kirby Query Language](https://getkirby.com/docs/guide/blueprints/query-language) and therefore customizable. It is totally up to you, how the page will appear to your users. You have access to `$page`, `site` and `kirby`.
+
+The default is `{{ page.title }}`.
+
+In order to change the default add `gearsdigital.enhanced-toolbar-link-dialog.link.title` to your `site/config.php`.
+
+### Example
+```php
+// site/config.php
+return [
+    'gearsdigital.enhanced-toolbar-link-dialog.link.title' => '### {{ page.title }} ###',
+];
+```
+
+This will wrap the text in `###` => (`### In the jungle of Sumatra ###`)
 
 ## Available translations
-
+``
 - German
 - English
 

--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Http\Url;
+use Kirby\Toolkit\Str;
 
 Kirby::plugin('gearsdigital/enhanced-toolbar-link-dialog', [
     'api'          => [
@@ -13,7 +14,12 @@ Kirby::plugin('gearsdigital/enhanced-toolbar-link-dialog', [
                         return $page->id();
                     },
                     'title' => function ($page) {
-                        return $page->title()->value();
+                        $query = option('gearsdigital.enhanced-toolbar-link-dialog.link.title', '{{ page.title }}');
+                        return Str::template($query, [
+                            'page' => $page,
+                            'site' => site(),
+                            'kirby' => kirby(),
+                        ]);
                     },
                     'slug'  => function ($page) {
                         return URL::makeAbsolute($page->parent().DS.$page->slug());
@@ -54,7 +60,7 @@ Kirby::plugin('gearsdigital/enhanced-toolbar-link-dialog', [
             'gearsdigital.enhanced-toolbar-link-dialog.external' => 'External Link',
             'gearsdigital.enhanced-toolbar-link-dialog.empty'    => 'No pages found',
             'gearsdigital.enhanced-toolbar-link-dialog.target.title' => 'Link Target',
-            'gearsdigital.enhanced-toolbar-link-dialog.target.help' => 'Specify where to open the linked document.',
+            'gearsdigital.enhanced-toolbar-link-dialog.target.help' => 'Specify where to open the linked document.'
         ],
         'de' => [
             'gearsdigital.enhanced-toolbar-link-dialog.internal' => 'Interner Link',


### PR DESCRIPTION
This PR adds the ability to fully customize the apperance of the displayed page title.

The list item text is now created using the [Kirby Query Language](https://getkirby.com/docs/guide/blueprints/query-language) and it's totally up to you, how the title will appear to your users.

You have access to `$page`, `site` and `kirby`.

Closes #12