### PR TITLE
fix: dialog tabs behave now as expected in nested tabs scenarios

### DIFF
--- a/src/components/EnhancedToolbarLinkDialog.vue
+++ b/src/components/EnhancedToolbarLinkDialog.vue
@@ -13,7 +13,6 @@
       <nav>
         <k-button
           v-for="tab in tabs"
-          :link="'#' + tab.name"
           :current="currentTab && currentTab.name === tab.name"
           class="k-tab-button"
           @click="selectTab(tab)"


### PR DESCRIPTION
This MR fixes dialog tab behaviour if you have a nested tab secenario as described in #14. 

Closes #14