### PR TITLE
Clarify placeholder text of link input field

### DIFF
--- a/src/components/fields/EnhancedToolbarAutosuggestField.vue
+++ b/src/components/fields/EnhancedToolbarAutosuggestField.vue
@@ -6,7 +6,7 @@
 			:counter="false"
 			icon="file-document"
 			:label="label"
-			placeholder="Enter a search term…"
+			placeholder="Enter a URL or search term…"
 			name="text"
 			@input="updateSearch"
 		/>


### PR DESCRIPTION
As the README says that the field also takes URLs, this should be reflected UI wise for better user experience.